### PR TITLE
Handle missing region in ARN parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,1 +1,39 @@
+"""AWS Visual Swiss Army Knife utilities."""
 
+from __future__ import annotations
+
+
+def get_region_from_arn(arn: str) -> str | None:
+    """Extract the region component from an AWS ARN.
+
+    Parameters
+    ----------
+    arn:
+        Full Amazon Resource Name.
+
+    Returns
+    -------
+    str | None
+        Region string if present. Returns ``None`` if the ARN does not
+        include a region component.
+
+    Raises
+    ------
+    ValueError
+        If the ARN does not have the expected structure.
+    """
+    parts = arn.split(":", 5)
+    if len(parts) < 6 or parts[0] != "arn":
+        raise ValueError(f"Malformed ARN: {arn}")
+
+    region = parts[3]
+    return region or None
+
+
+if __name__ == "__main__":
+    import sys
+
+    if not sys.argv[1:]:
+        raise SystemExit("usage: python main.py <arn>")
+
+    print(get_region_from_arn(sys.argv[1]))

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,18 @@
+import pytest
+
+from main import get_region_from_arn
+
+
+def test_region_extraction():
+    arn = "arn:aws:lambda:us-west-2:123456789012:function:my-func"
+    assert get_region_from_arn(arn) == "us-west-2"
+
+
+def test_s3_arn_without_region():
+    arn = "arn:aws:s3:::my_corporate_bucket"
+    assert get_region_from_arn(arn) is None
+
+
+def test_invalid_arn_raises():
+    with pytest.raises(ValueError):
+        get_region_from_arn("not-an-arn")


### PR DESCRIPTION
## Summary
- add `get_region_from_arn` helper to parse AWS ARNs
- return `None` instead of failing when ARN lacks region
- cover ARN parsing with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8d1024f4483229bf9f8043bd3cfb3